### PR TITLE
updated the target to be ASP Net 5.0

### DIFF
--- a/images/init/template/Dockerfile.in
+++ b/images/init/template/Dockerfile.in
@@ -1,7 +1,7 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["{FUNCTION_NAME}.csproj", "."]
 RUN dotnet restore "{FUNCTION_NAME}.csproj"

--- a/images/init/template/Project.csproj
+++ b/images/init/template/Project.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi Daniel,

I've recently tried using the docker image was referenced in the fnproject.io documentation for the dotnet. Unfortunately, I came across the fact that the referenced docker images in the Dockerfile were no longer available.

I've updated the reference to be 5.0 which is the current version and used that as the target executable runtime. I've tested with the default fn init and executes successfully with both fnproject.io and Oracle Functions.

Thanks,
Jason.